### PR TITLE
crisp rendering

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,11 +27,11 @@
             left: 50%;
             transform: translate(-50%, -50%);
             border: 1px solid var(--color-dark);
+            image-rendering: pixelated;
 
             @media (prefers-color-scheme: dark) {
                border: 1px solid var(--color-lite);
             }
-
         }
 
         #raylib-example-select {


### PR DESCRIPTION
Demos now look bit more `crispy` ..  font rendering of text that is not pixel aligned looks bit weird, but its only noticeable when it is zoomed in.. maybe we can scale resolution depending on the zoom level? 

Source:

https://developer.mozilla.org/en-US/docs/Games/Techniques/Crisp_pixel_art_look

Before:

![image](https://github.com/tsoding/zozlib.js/assets/50113451/eb6c4bd4-bcb1-4fe6-8b0c-9b992dddd21a)

![image](https://github.com/tsoding/zozlib.js/assets/50113451/f5ed1123-ed12-495b-8013-dcdf561333bf)


After:

![image](https://github.com/tsoding/zozlib.js/assets/50113451/5c776467-de83-40d6-a0ff-bcb9088a0050)

![image](https://github.com/tsoding/zozlib.js/assets/50113451/90784921-28bb-4b93-a7b8-a169917442ab)

