### PR TITLE
Add IsKey* Functions

### DIFF
--- a/raylib.js
+++ b/raylib.js
@@ -187,9 +187,23 @@ class RaylibJs {
     IsKeyPressed(key) {
         return !this.prevPressedKeyState.has(key) && this.currentPressedKeyState.has(key);
     }
+
+    IsKeyPressedRepeat(key) {
+        return false;
+    }
+
     IsKeyDown(key) {
         return this.currentPressedKeyState.has(key);
     }
+
+    IsKeyReleased(key) {
+        return this.prevPressedKeyState.has(key) && !this.currentPressedKeyState.has(key);
+    }
+
+    IsKeyUp(key) {
+        return !this.currentPressedKeyState.has(key);
+    }
+
     GetMouseWheelMove() {
       return this.currentMouseWheelMoveState;
     }


### PR DESCRIPTION
This adds the three other `IsKey____()` functions...

``` c
IsKeyPressedRepeat(key)
IsKeyReleased(key)
IsKeyUp(key)
```

There aren't any official raylib examples that use these functions, so I avoided adding them as examples. It can be tested, however, by adding the following to `core_input_keys.c`:

``` c
if (IsKeyReleased(KEY_R)) {
    ballPosition.x = (float)GetScreenWidth()/2;
    ballPosition.y = (float)GetScreenHeight()/2;
}
```
