### PR TITLE
Make raylibJs global when DEBUG flag is present

### DIFF
--- a/index.html
+++ b/index.html
@@ -100,6 +100,7 @@
                     raylibJs.stop();
                 }
                 raylibJs = new RaylibJs();
+                if (localStorage.DEBUG_RAYLIB_JS) window.raylibJs = raylibJs;
                 raylibJs.start({
                     wasmPath: `wasm/${selectedWasm}.wasm`,
                     canvasId: "game",


### PR DESCRIPTION
As it was stated in "Rewriting Raylib in JavaScript" video, it is really useful to have ability to fiddle with things in devtools while debugging. So, we could bring this ability back