### PR TITLE
Add support for GetMonitorWidth/Height

### DIFF
--- a/raylib.js
+++ b/raylib.js
@@ -129,6 +129,12 @@ class RaylibJs {
     GetScreenHeight() {
         return this.ctx.canvas.height;
     }
+    GetMonitorWidth(monitor){
+        return window.innerWidth;
+    }
+    GetMonitorHeight(monitor){
+        return window.innerHeight;
+    }
 
     GetFrameTime() {
         // TODO: This is a stopgap solution to prevent sudden jumps in dt when the user switches to a differen tab.


### PR DESCRIPTION
the css needs to be changed to this to actually view the effect:

```css
        body {
            /* Lite Mode */
            background: var(--color-lite);
            color: var(--color-dark);
            margin: 0px;
            border: 0;
           /*  Disable scrollbars */
            overflow: hidden;
            /* No floating content on sides */
            display: block;
            /* Dark Mode */
            @media (prefers-color-scheme: dark) {
                background: var(--color-dark);
                color: var(--color-lite);
            }
        }

        #game {
            position: absolute;
            top: 0px;
            left: 0px;
            /* transform: translate(-50%, -50%); */
            border: 1px solid var(--color-dark);

            @media (prefers-color-scheme: dark) {
               border: 1px solid var(--color-lite);
            }

        }
```