### PR TITLE
Use -ffreestanding flag to prevent stdlib function usage produced by Clang optimizations

### DIFF
--- a/nob.c
+++ b/nob.c
@@ -71,6 +71,7 @@ bool build_wasm(void)
         nob_cmd_append(&cmd, "--target=wasm32");
         nob_cmd_append(&cmd, "-I./include");
         nob_cmd_append(&cmd, "--no-standard-libraries");
+        nob_cmd_append(&cmd, "-ffreestanding");
         nob_cmd_append(&cmd, "-Wl,--export-table");
         nob_cmd_append(&cmd, "-Wl,--no-entry");
         nob_cmd_append(&cmd, "-Wl,--allow-undefined");


### PR DESCRIPTION
When the `--no-standard-libraries` flag prevents Clang from *linking* with the standard library, it doesn't prevent Clang from using stdlib functions during code optimization. 

A common case is the `memset` function being introduced by loop optimizations ([LLVM issue #63232](https://github.com/llvm/llvm-project/issues/63232)).

To prevent these unwanted imports in the compiled WASM module, we should use the `-ffreestanding` flag to ensure Clang doesn't use any stdlib functions.
